### PR TITLE
Add D's Gems

### DIFF
--- a/gems/index.yml
+++ b/gems/index.yml
@@ -1,0 +1,3 @@
+title: D's Gems
+ordering:
+- unicode

--- a/gems/unicode.md
+++ b/gems/unicode.md
@@ -1,0 +1,3 @@
+# Unicode in D
+
+To be filled.

--- a/index.yml
+++ b/index.yml
@@ -4,3 +4,4 @@ repo: dlang-tour/ukrainian
 ordering:
 - welcome
 - basics
+- gems


### PR DESCRIPTION
There was a flaw in the link sanity checker, which verifies that all internal links are valid.

With https://github.com/stonemaster/dlang-tour/pull/472, this is intended to be fixed.
However in `basics/alias-strings` there's a link to `gems/unicode`, hence I added this page.
